### PR TITLE
use parametrization in the tests

### DIFF
--- a/test/filtering/test_smoothing.py
+++ b/test/filtering/test_smoothing.py
@@ -7,13 +7,12 @@ import pytest
 from itk_cucim.filtering import smoothing
 
 
-class TestSmoothing():
-
+class TestSmoothing:
     def setup_class(self):
-        data = Path(__file__).absolute().parent.parent / 'input' / 'head_mr.mha'
+        data = Path(__file__).absolute().parent.parent / "input" / "head_mr.mha"
         self.image = itk.imread(data)
 
-    @pytest.mark.parametrize('radius', [1, (3, 2, 1)])
+    @pytest.mark.parametrize("radius", [1, (3, 2, 1)])
     def test_median_image_filter(self, radius):
 
         median_ref = itk.median_image_filter(self.image, radius=radius)

--- a/test/filtering/test_smoothing.py
+++ b/test/filtering/test_smoothing.py
@@ -13,7 +13,7 @@ class TestSmoothing():
         data = Path(__file__).absolute().parent.parent / 'input' / 'head_mr.mha'
         self.image = itk.imread(data)
 
-    @pytest.mark.parametrize('radius', [(1, 2, 1), (3, 2, 1)])
+    @pytest.mark.parametrize('radius', [1, (3, 2, 1)])
     def test_median_image_filter(self, radius):
 
         median_ref = itk.median_image_filter(self.image, radius=radius)

--- a/test/filtering/test_smoothing.py
+++ b/test/filtering/test_smoothing.py
@@ -1,20 +1,25 @@
-from itk_cucim.filtering import smoothing
-import itk
-import numpy as np
-
 from pathlib import Path
 
-def test_median_image_filter():
-    image = itk.imread(Path(__file__).absolute().parent.parent / 'input' / 'head_mr.mha')
+import itk
+import numpy as np
+import pytest
 
-    median_ref = itk.median_image_filter(image, radius=[1,2,1])
-    median_cucim = smoothing.cucim_median_image_filter(image, radius=[1,2,1])
+from itk_cucim.filtering import smoothing
 
-    comparison = itk.comparison_image_filter(median_ref, median_cucim, verify_input_information=True)
-    assert np.sum(comparison) == 0.0
 
-    median_ref = itk.median_image_filter(image, radius=[3,2,1])
-    median_cucim = smoothing.cucim_median_image_filter(image, radius=[3,2,1])
+class TestSmoothing():
 
-    comparison = itk.comparison_image_filter(median_ref, median_cucim, verify_input_information=True)
-    assert np.sum(comparison) == 0.0
+    def setup_class(self):
+        data = Path(__file__).absolute().parent.parent / 'input' / 'head_mr.mha'
+        self.image = itk.imread(data)
+
+    @pytest.mark.parametrize('radius', [(1, 2, 1), (3, 2, 1)])
+    def test_median_image_filter(self, radius):
+
+        median_ref = itk.median_image_filter(self.image, radius=radius)
+        median_cucim = smoothing.cucim_median_image_filter(self.image, radius=radius)
+
+        comparison = itk.comparison_image_filter(
+            median_ref, median_cucim, verify_input_information=True
+        )
+        assert np.sum(comparison) == 0.0


### PR DESCRIPTION
This PR uses `pytest.mark.parametrize` to repeat tests across different radius values. A `setup_class` method was used to avoid repeating the intial data loading.

The only non-stylistic change was modifying the [1, 2, 1] radius to be just a scalar value of 1 to make sure the scalar gets broadcast to all dimensions as expected.

The order of imports at the top was sorted to match a style used by the [isort](https://github.com/PyCQA/isort) tool (standard lib imports at top, third-party next and current package last).
